### PR TITLE
Edits to align with Ecma house style

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WinterTC55/runtime-keys.git"
 	},
 	"scripts": {
-		"build": "ecmarkup spec.html out.html"
+		"build": "ecmarkup spec.html out.html",
+		"watch": "ecmarkup --watch --verbose --lint-spec spec.html out.html"
 	},
 	"devDependencies": {
 		"ecmarkup": "^22.0.0"

--- a/spec.html
+++ b/spec.html
@@ -19,93 +19,104 @@
   location: https://github.com/WinterTC55/runtime-keys
   contributors: WinterTC55
   </pre>
+
+  <emu-intro id="sec-intro">
+    <h1>Introduction</h1>
+
+    <p>This Technical Report defines a canonical source for identifiers of unique ECMAScript runtime environments, known as <em>runtime keys</em>.</p>
+  </emu-intro>
+
   <emu-clause id="sec-scope">
     <h1>Scope</h1>
-    <p>This Technical Report defines a registry of runtime keys for JavaScript runtime environments.</p>
 
-    <emu-clause id="sec-description">
-      <h1>Description</h1>
-      <p>A <dfn>runtime key</dfn> is a unique string identifier that represents a specific JavaScript runtime environment. Runtime keys provide a standardized mechanism for identifying JavaScript runtimes in a variety of contexts, including but not limited to project configuration files, package manifests, conditional exports, and runtime detection mechanisms. These keys are meant to particularly represent server environments. Browsers should still be generally referenced by other mechanisms such as the browserslist project.</p>
+    <p>Runtime keys provide a consistent and predictable mechanism for identifying ECMAScript runtimes in a variety of contexts, including but not limited to project configuration files, package manifests, conditional exports, and runtime detection mechanisms. This document focusses on providing informative identifiers primarily for web servers, though other ECMAScript server environments may find it useful. These keys are not intended to be used in web browsers, which should be referenced by other mechanisms such as the browserslist project.</p>
+    <p>This Report defines:</p>
+    <ul>
+      <li>the canonical source of runtime keys and associated metadata,</li>
+      <li>guidance for future ECMAScript runtimes to submit runtime keys, and</li>
+      <li>TC55's governance process for adding and modifying runtime keys to the Report.</li>
+    </ul>
 
-      <p>This specification defines:</p>
-      <ul>
-        <li>The registry of runtime keys and associated metadata</li>
-        <li>The normative requirements for runtime keys</li>
-        <li>The governance process for adding and modifying registry entries</li>
-      </ul>
+    <emu-note>
+      <p>This Report does not define <em>how</em> runtime keys should be used by tools or libraries. The purpose of this Report is to prevent conflicts and provide a reliable, authoritative source of runtime identifiers.</p>
+    </emu-note>
 
-      <emu-note>
-        <p>This specification does not define <em>how</em> runtime keys should be used by tools or libraries. The purpose of this registry is to prevent conflicts and provide a reliable, authoritative source of runtime identifiers that the community can build tooling around.</p>
-      </emu-note>
+    <emu-note>
+      <p>Inclusion in this Report does not imply that the specified runtime is conformant with any ECMA TC55 specification, including the WinterTC Minimum Common API. Inclusion does not imply endorsement of any kind.</p>
+    </emu-note>
+  </emu-clause>
 
-      <emu-note>
-        <p>Inclusion in this registry does not imply that the specified runtime is conformant with any WinterTC specification, including the Minimum Common API. Inclusion does not imply endorsement of any kind.</p>
-      </emu-note>
+  <emu-clause id="sec-terms-and-definitions">
+    <h1>Terms and definitions</h1>
+
+    <p>For the purposes of this document, the following terms and definitions apply.</p>
+
+    <emu-clause id="term-runtime">
+      <h1><dfn variants="ECMAScript runtimes">ECMAScript runtime</dfn></h1>
+      <p>implementation of the ECMA-262 ECMAScript langauge specification</p>
+    </emu-clause>
+
+    <emu-clause id="term-runtime-key">
+      <h1><dfn variants="runtime keys,Runtime keys">runtime key</dfn></h1>
+      <p>unique string identifier that represents a specific ECMAScript runtime environment</p>
     </emu-clause>
   </emu-clause>
 
-  <emu-clause id="sec-conformance">
-    <h1>Conformance</h1>
-    <p>This document is a Technical Report and does not define conformance requirements for implementations. The registry defined herein is informative and provides a canonical list of runtime keys for use by the JavaScript ecosystem.</p>
-  </emu-clause>
-
-  <emu-clause id="sec-normative-references">
-    <h1>Normative References</h1>
-    <p>There are no normative references.</p>
-  </emu-clause>
-
-  <emu-clause id="sec-runtime-key-requirements">
-    <h1>Runtime Key Requirements</h1>
+  <emu-clause id="sec-runtime-key-structure">
+    <h1>Runtime key structure</h1>
 
     <emu-clause id="sec-key-format">
-      <h1>Key Format</h1>
-      <p>A runtime key must satisfy the following requirements:</p>
+      <h1>Key format</h1>
+      <p>A runtime key satisfies all of the following conditions:</p>
       <ul>
-        <li>It must be a string value</li>
-        <li>It must be usable in common configuration formats such as JSON and YAML</li>
-        <li>It must meaningfully represent the associated runtime environment</li>
-        <li>It must be simple and unambiguous</li>
+        <li>It is a string value.</li>
+        <li>It is usable in common configuration formats such as JSON and YAML.</li>
+        <li>It meaningfully represents the associated runtime environment.</li>
+        <li>It is simple and unambiguous.</li>
       </ul>
 
       <emu-note>
-        <p>Future versions of this specification may define a formal grammar for allowable characters in runtime keys.</p>
+        <p>Future versions of this Report may define a formal grammar for allowable characters in runtime keys.</p>
       </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-key-uniqueness">
-      <h1>Key Uniqueness</h1>
-      <p>A runtime key must not conflict with:</p>
+      <h1>Key uniqueness</h1>
+      <p>A runtime key included in this Report will not conflict with the following:</p>
       <ul>
-        <li>Any other existing runtime key in this registry</li>
-        <li>Existing Browserslist browser entries (excludes references to server runtimes within Browserslist)</li>
+        <li>any other existing runtime key in this Report, or</li>
+        <li>
+          any existing Browserslist <em>browser</em> entries.
+          <emu-note>This explicitly excludes references to <em>server</em> runtimes within Browserslist.</emu-note>
+        </li>
       </ul>
     </emu-clause>
 
     <emu-clause id="sec-key-naming-guidelines">
-      <h1>Key Naming Guidelines</h1>
-      <p>Runtime keys are subject to expert review by WinterTC members. Keys should:</p>
+      <h1>Key naming guidelines</h1>
+      <p>Runtime keys are subject to expert review by TC55. Acceptable keys will:</p>
       <ul>
-        <li>Avoid being too similar to existing keys</li>
-        <li>Avoid similarity to common English words or offensive terms</li>
-        <li>Avoid being too generic or similar to general terminology such as "Web Runtimes", "Edge Runtimes", or "JavaScript Runtimes"</li>
-        <li>Demonstrate reasonable specificity and clarity</li>
+        <li>avoid being too similar to existing keys,</li>
+        <li>avoid similarity to common English words or offensive terms,</li>
+        <li>avoid being too generic or similar to general terminology such as "Web Runtimes", "Edge Runtimes", or "JavaScript Runtimes", and</li>
+        <li>demonstrate reasonable specificity and clarity.</li>
       </ul>
     </emu-clause>
 
     <emu-clause id="sec-runtime-existence">
-      <h1>Runtime Existence Requirement</h1>
-      <p>The runtime environment represented by a key must actually exist, whether as open source, source-available, or proprietary software. Registry entries exist to identify real runtimes, not to reserve names for future projects.</p>
+      <h1>Runtime existence validation</h1>
+      <p>The runtime environment represented by a key must actually exist, whether as open source, source-available, or proprietary software. Entries in this Report exist to identify real runtimes, not to reserve names for future projects.</p>
 
       <emu-note>
-        <p>A runtime should demonstrate "proof of use" before being added to the registry. Examples include usage in package.json exports fields, published documentation, or active community adoption.</p>
+        <p>A runtime should demonstrate "proof of use" before being added to the Report. Examples include usage in package.json exports fields, published documentation, or active community adoption.</p>
       </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-runtime-metadata">
-      <h1>Runtime Metadata</h1>
+      <h1>Runtime metadata</h1>
       <p>Each runtime key entry includes the following metadata:</p>
       <ul>
-        <li><strong>Organization</strong> (required): The organization or individual responsible for the runtime</li>
+        <li><strong>Organization</strong> (required): The organisation or individual responsible for the runtime</li>
         <li><strong>Name</strong> (required): The human-readable name of the runtime</li>
         <li><strong>Key</strong> (required): The unique string identifier</li>
         <li><strong>Description</strong> (required): A brief description of the runtime</li>
@@ -116,12 +127,12 @@
     </emu-clause>
   </emu-clause>
 
-  <emu-clause id="sec-runtime-registry">
-    <h1>Runtime Key Registry</h1>
-    <p>The following table lists all registered runtime keys, sorted alphabetically by Organization.</p>
+  <emu-clause id="sec-runtime-source">
+    <h1>Canonical source for runtime keys</h1>
+    <p>The following table lists all previously recorded runtime keys, sorted alphabetically by organisation.</p>
 
     <emu-note>
-      <p>This section is generated from the machine-readable registry data (see <emu-xref href="#sec-machine-readable-registry"></emu-xref>). In the build process, this content should be dynamically generated from <code>runtime-keys.json</code>.</p>
+      <p>This section is generated from the machine-readable source data (see <emu-xref href="#sec-machine-readable-source"></emu-xref>). In the build process, this content should be dynamically generated from <code>runtime-keys.json</code>.</p>
     </emu-note>
 
     <emu-table id="table-runtime-keys" caption="Registered Runtime Keys">
@@ -279,55 +290,53 @@
   </emu-clause>
 
   <emu-clause id="sec-governance">
-    <h1>Governance and Modification Process</h1>
+    <h1>Governance and modification process</h1>
 
     <emu-clause id="sec-adding-entries">
-      <h1>Adding Registry Entries</h1>
-      <p>All JavaScript runtimes are welcome to propose a key for inclusion in this registry, subject to the requirements specified in <emu-xref href="#sec-runtime-key-requirements"></emu-xref>. Runtime entries in this registry are encouraged, but not required, to participate in WinterTC.</p>
+      <h1>Proposing entries for future editions</h1>
+      <p>All ECMAScript runtimes are welcome to propose a key for inclusion in this Report, subject to the attributes specified in <emu-xref href="#sec-runtime-key-structure"></emu-xref>. Runtimes which contribute to this Report are encouraged, but not required, to participate in Ecma TC55.</p>
 
       <emu-clause id="sec-proposal-process">
-        <h1>Proposal Process</h1>
+        <h1>Proposal process</h1>
         <emu-alg>
           1. The proposer creates a pull request in the runtime-keys repository.
-          1. The pull request must add the runtime entry to the machine-readable registry data file (<code>runtime-keys.json</code>).
-          1. The entry must include all required metadata fields as specified in <emu-xref href="#sec-runtime-metadata"></emu-xref>.
-          1. The entry must be inserted in alphabetical order by Organization.
-          1. The pull request must be reviewed by WinterTC members.
-          1. At least two WinterTC members not directly affiliated with the proposed runtime must approve the pull request.
-          1. The pull request must be formally approved at a WinterTC plenary meeting before merging.
-          1. After plenary approval, designated editors merge the pull request and update the published registry.
+          1. The pull request adds the runtime entry to the machine-readable source data file (<code>runtime-keys.json</code>).
+          1. The entry includes all mandatory metadata fields as described in <emu-xref href="#sec-runtime-metadata"></emu-xref>.
+          1. The entry is inserted in alphabetical order by organisation.
+          1. [id="step-approval-process"] The pull request is reviewed by WinterTC participants.
+          1. At least two delegates within TC55 not directly affiliated with the proposed runtime approve the pull request.
+          1. The pull request is be formally approved at a TC55 plenary meeting before merging.
+          1. After plenary approval, designated editors merge the pull request and update the current draft Report.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-expert-review">
-        <h1>Expert Review</h1>
-        <p>All proposed entries undergo expert review to ensure compliance with the naming guidelines specified in <emu-xref href="#sec-key-naming-guidelines"></emu-xref> and other requirements. Reviewers evaluate whether:</p>
+        <h1>Expert review</h1>
+        <p>All proposed entries undergo expert review to ensure compliance with the naming guidelines specified in <emu-xref href="#sec-key-naming-guidelines"></emu-xref> and other expectations. Reviewers evaluate whether:</p>
         <ul>
-          <li>The proposed key is appropriately specific and non-generic</li>
-          <li>The runtime has demonstrated proof of use or adoption</li>
-          <li>The key does not conflict with existing entries or Browserslist identifiers</li>
-          <li>The metadata is complete and accurate</li>
+          <li>the proposed key is appropriately specific and non-generic,</li>
+          <li>the runtime has demonstrated proof of use or adoption,</li>
+          <li>the key does not conflict with existing entries or Browserslist identifiers, and</li>
+          <li>the metadata is complete and accurate.</li>
         </ul>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-modifying-entries">
-      <h1>Modifying Registry Entries</h1>
+      <h1>Modifying entries</h1>
 
       <emu-clause id="sec-metadata-modification">
-        <h1>Metadata Modification</h1>
-        <p>Modifications to runtime metadata (organization, name, description, website, or repository) follow the same process as adding entries:</p>
+        <h1>Metadata modification</h1>
+        <p>Modifications to runtime metadata (organisation, name, description, website, or repository) follow the same process as adding entries:</p>
         <emu-alg>
           1. The proposer creates a pull request modifying the entry in <code>runtime-keys.json</code>.
-          1. At least two WinterTC members not affiliated with the runtime must approve the pull request.
-          1. The modification must be formally approved at a WinterTC plenary meeting.
-          1. After plenary approval, designated editors merge the pull request.
+          1. The proposal continues as described starting at step <emu-xref href="#step-approval-process"></emu-xref> in the approval process.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-key-immutability">
-        <h1>Key Immutability</h1>
-        <p>To prevent breaking existing tools and configurations that depend on runtime keys, <strong>runtime keys are immutable</strong> and must not be modified except in extraordinary circumstances requiring plenary consensus.</p>
+        <h1>Key immutability</h1>
+        <p>To prevent breaking existing tools and configurations that depend on runtime keys, <strong>runtime keys are immutable</strong> and will not be modified except in extraordinary circumstances requiring plenary consensus.</p>
       </emu-clause>
 
       <emu-clause id="sec-deprecation">
@@ -335,35 +344,34 @@
         <p>Runtime keys may be deprecated to indicate that a runtime project is inactive or discontinued. To deprecate a key:</p>
         <emu-alg>
           1. The proposer creates a pull request setting the `deprecated` field to `true` in <code>runtime-keys.json</code>.
-          1. The pull request follows the standard approval process.
-          1. After plenary approval and merge, the key is marked as deprecated in the published registry.
+          1. The proposal continues as described starting at step <emu-xref href="#step-approval-process"></emu-xref> in the approval process.
         </emu-alg>
 
         <p>Deprecated keys may be undeprecated if the original runtime project resumes activity, following the same approval process. Implementations should not add support for deprecated keys.</p>
 
         <emu-note>
-          <p>Deprecated keys remain in the registry to preserve historical information and prevent reuse that could cause confusion.</p>
+          <p>Deprecated keys remain in the Report to preserve historical information and prevent reuse that could cause confusion.</p>
         </emu-note>
       </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-publication-cadence">
-      <h1>Publication Cadence</h1>
-      <p>The registry is published on a semi-annual basis as an ECMA Technical Report. Changes approved at plenary meetings between publication cycles are available in the draft registry maintained in the WinterTC runtime-keys repository.</p>
+      <h1>Publication cadence</h1>
+      <p>This Report is published on a semi-annual basis as an ECMA Technical Report. Changes approved at TC55 plenary meetings between publication cycles can be found in the publicly-available draft maintained in the WinterTC runtime-keys repository.</p>
     </emu-clause>
   </emu-clause>
 
-  <emu-annex id="sec-machine-readable-registry">
-    <h1>Machine-Readable Registry Data</h1>
-    <p>The authoritative, machine-readable form of the runtime key registry is maintained as a JSON file: <code>runtime-keys.json</code>.</p>
+  <emu-annex id="sec-machine-readable-source">
+    <h1>Machine-readable canonical source</h1>
+    <p>The authoritative, machine-readable form of the runtime key source is maintained as a JSON file: <code>runtime-keys.json</code>.</p>
 
     <emu-annex id="sec-json-schema">
-      <h1>JSON Schema</h1>
-      <p>The registry JSON file conforms to the following structure:</p>
+      <h1>JSON schema</h1>
+      <p>The runtime keys source data JSON file conforms to the following structure:</p>
       <pre><code class="language-json">{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Runtime Keys Registry",
-  "description": "A registry of runtime keys for JavaScript runtime environments",
+  "title": "Runtime Keys",
+  "description": "A collection of runtime keys for ECMAScript runtime environments",
   "version": "1.0.0",
   "lastModified": "YYYY-MM-DD",
   "runtimes": [
@@ -380,9 +388,9 @@
 }</code></pre>
     </emu-annex>
 
-    <emu-annex id="sec-accessing-registry">
-      <h1>Accessing the Registry</h1>
-      <p>The current machine-readable registry is available at:</p>
+    <emu-annex id="sec-accessing-source">
+      <h1>Accessing the source data</h1>
+      <p>The current machine-readable source is available at:</p>
       <ul>
         <li>Draft version: <code>https://github.com/WinterTC55/runtime-keys/blob/main/runtime-keys.json</code></li>
         <li>Published version: To be determined upon ECMA TR publication</li>
@@ -391,7 +399,7 @@
   </emu-annex>
 
   <emu-annex id="sec-example-usage">
-    <h1>Example Usage</h1>
+    <h1>Example usage</h1>
     <p>This annex provides non-normative examples of how runtime keys may be used in practice.</p>
 
     <emu-note>
@@ -399,7 +407,7 @@
     </emu-note>
 
     <emu-annex id="sec-package-json-example">
-      <h1>Package.json Example</h1>
+      <h1>package.json example</h1>
       <p>A library package might use runtime keys in its <code>package.json</code> to specify conditional exports and runtime version requirements:</p>
       <pre><code class="language-json">{
   "name": "example-library",
@@ -440,5 +448,13 @@
 }</code></pre>
     </emu-annex>
   </emu-annex>
+
+<emu-annex id="sec-biblio" back-matter>
+  <h1>Bibliography</h1>
+  <p>
+    ECMA-262, <i>ECMAScript&reg; Language Specification</i><br />
+    <a href="https://tc39.es/ecma262/multipage/">https://tc39.es/ecma262/multipage/</a>
+  </p>
+</emu-annex>
 </body>
 </html>


### PR DESCRIPTION
@Ethan-Arrowood this your first draft is so good that I had the cognitive overhead to tackle house styles stuff, which I usually safe for far later drafts. I'm incredibly impressed, what a phenomenal start.

The below changes are just a starting point, not an ending one. Do not be afraid to further (aggressively even!) edit. I'll do a review with comments forthright so it's clear why some of the edits were made.


The most important notes here are:

* I'm not a huge fan of calling it a registry when it's in TR form. Let's see if we can get away with never actually saying the word in the formal doc.
* TRs are informative, not normative, so we have to avoid words like "requirement", "must", "shall"
* Formal documents should reference "ECMAScript" not "JavaScript"
* We have to make sure we stay within the bounds of the committee's charter