### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,11 +24,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Create `out` dir
-        run: |
-          mkdir -p out
-          mv out.html out/index.html
-
       - name: Upload `out` to Deno Deploy
         uses: denoland/deployctl@v1
         with:


### PR DESCRIPTION
In #34, the `build` npm script was changed to output the result of the ecmarkup build into `out/index.html`, where it was `out.html` previously. As it turns out, this broke CI because a later step moved `out.html` to `out/index.html`. This patch removes that CI step to unbreak the build.